### PR TITLE
Webpack Runner

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -8,7 +8,10 @@
         "no-param-reassign": 0,
         "no-new": 0,
         "import/newline-after-import": 0,
-        "import/no-dynamic-require": 0
+        "import/no-dynamic-require": 0,
+        "import/no-extraneous-dependencies": 0,
+        "strict": 0,
+        "no-plusplus": 0
     },
     "globals": {
         "window": true,
@@ -28,6 +31,7 @@
         "by": true,
         "isAngularSite": true,
         "protractor": true,
-        "element": true
+        "element": true,
+        "jasmine": true
     }
 }

--- a/.jestrc
+++ b/.jestrc
@@ -5,10 +5,11 @@
     "collectCoverage": true,
     "coverageDirectory": "coverage",
     "testRegex": "\\.test\\.js$",
-    "unmockedModulePathPatterns": ["mocks"],
+    "unmockedModulePathPatterns": ["mocks", "colors"],
     "coveragePathIgnorePatterns": ["/node_modules/", "/mocks/"],
     "clearMocks": true,
     "moduleNameMapper": {
         "package\\.json$": "<rootDir>/tests/mocks/package.js"
-    }
+    },
+    "testEnvironment": "node"
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
         "universal"
     ],
     "dependencies": {
-        "webpack-merge": "0.14.0"
+        "webpack-merge": "0.14.0",
+        "colors": "1.1.2"
     },
     "devDependencies": {
         "eslint": "3.7.1",
@@ -24,6 +25,7 @@
         "eslint-plugin-import": "1.16.0",
 
         "jest-cli": "16.0.2",
+        "jasmine-expect": "3.7.0",
         "esdoc": "0.4.8",
         "esdoc-es7-plugin": "0.0.3",
         "esdoc-uploader": "1.0.1",

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@
 const path = require('path');
 const fs = require('fs');
 const merge = require('webpack-merge');
+const WebpackNodeUtilsRunner = require('./runner');
 const rootPath = process.cwd();
 /**
  * The module's core: A set of static methods that allows you to manage multiple Webpack
@@ -210,3 +211,4 @@ class WebpackNodeUtils {
 }
 
 module.exports = WebpackNodeUtils;
+module.exports.WebpackNodeUtilsRunner = WebpackNodeUtilsRunner;

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,7 @@ const rootPath = process.cwd();
  * configuration files, generate the list of external dependencies from your
  * `package.json`, do dynamic requires on runtime and read files without even knowing
  * where the bundle is located.
+ * @class
  */
 class WebpackNodeUtils {
     /**

--- a/src/runner.js
+++ b/src/runner.js
@@ -5,15 +5,56 @@
 const path = require('path');
 const fork = require('child_process').fork;
 const colors = require('colors/safe');
-
+/**
+ * This is a Webpack plugin for Node apps that allows the developer to start/stop the bundle
+ * execution while Webpack _watches_ the files.
+ * @class
+ */
 class WebpackNodeUtilsRunner {
-
+    /**
+     * Class constructor.
+     * @param {String|Null} entry Optional. The name of the Webpack entry the plugin will execute
+     *                            when the Webpack finishes building the files. If it's empty, the
+     *                            plugin will use the first one on the list of assets Webpack
+     *                            provides during compilation time.
+     * @return {WebpackNodeUtilsRunner}
+     */
     constructor(entry) {
+        /**
+         * The name of the Webpack entry the plugin will execute when the files change. It's value
+         * may be overwritten during the Webpack `compile` event (on the `_onAssetsEmitted` method).
+         * @type {String|Null}
+         * @ignore
+         */
         this._entry = entry || null;
+        /**
+         * On the Webpack `compile` event, the plugin will use this property to save the absolute
+         * path to the build file.
+         * @type {String|Null}
+         */
         this._entryPath = null;
+        /**
+         * A flag for the plugin to know if the build it's currently being executed or not.
+         * @type {Boolean}
+         */
         this._running = false;
+        /**
+         * When the build is executed, this property will store the instance of the process, so it
+         * can later be _killed_.
+         * @type {Object|Null}
+         */
         this._instance = null;
+        /**
+         * A flag for the plugin to know if the build information was already obtained and avoid
+         * running the same logic for every Webpack `after-emit` event.
+         * @type {Boolean}
+         */
         this._setup = false;
+        /**
+         * A dictionary of type of logs and colors for them that the plugin will use to build
+         * methods that log messages on their respective colors, using the `colors` package.
+         * @type {Object}
+         */
         this._logColors = {
             info: 'grey',
             error: 'red',
@@ -24,20 +65,32 @@ class WebpackNodeUtilsRunner {
         this._defineLogMethods();
         this._bindMethods();
     }
-
+    /**
+     * This is the method Webpack calls in order for the plugin to hook to the required events.
+     * @param {Object} compiler The Webpack compiler.
+     */
     apply(compiler) {
         compiler.plugin('after-emit', this._onAssetsEmitted);
         compiler.plugin('compile', this._onCompilationStarts);
         compiler.plugin('done', this._onCompilationEnds);
     }
-
+    /**
+     * Using the `_logColors` property, this method creates (more) methods for logging different
+     * events of the plugin. For example, on the `_logColors` dictionary you have `info: 'grey'`,
+     * this method creates a `_logInfo(msg)` method that logs out a message with the color `grey`.
+     * @ignore
+     */
     _defineLogMethods() {
         Object.keys(this._logColors).forEach((name) => {
             const fname = name.substr(0, 1).toUpperCase() + name.substr(1);
             this[`_log${fname}`] = msg => this._log(msg, this._logColors[name]);
         });
     }
-
+    /**
+     * Binds a list of the plugins methods to the instance so they can access it when Webpack
+     * invokes them.
+     * @ignore
+     */
     _bindMethods() {
         [
             'apply',
@@ -46,7 +99,16 @@ class WebpackNodeUtilsRunner {
             '_onCompilationEnds',
         ].forEach(m => (this[m] = this[m].bind(this)));
     }
-
+    /**
+     * This method is called on the Webpack `after-emit` event, it validates the entry asset set
+     * on the plugin constructor, finds a fallback if needed, inform via logging what's doing and
+     * saves the absolute path of the file it will use to run the build.
+     * @param {Object}   compilation A dictionary Webpack provides with the information of the
+     *                               assets it's going to build.
+     * @param {Function} callback    A callback function Webpack requires for the method to call
+     *                               after it finishes whatever it's doing.
+     * @ignore
+     */
     _onAssetsEmitted(compilation, callback) {
         if (!this._setup) {
             this._setup = true;
@@ -77,7 +139,11 @@ class WebpackNodeUtilsRunner {
 
         callback();
     }
-
+    /**
+     * This method is called on the Webpack `compile` event. It checks if the build is running and
+     * stops it.
+     * @ignore
+     */
     _onCompilationStarts() {
         if (this._entry && this._running && this._instance) {
             this._logInfo('Stopping bundle process');
@@ -86,7 +152,11 @@ class WebpackNodeUtilsRunner {
             this._running = false;
         }
     }
-
+    /**
+     * This method is called on the Webpack `done` event and it's in charge of start running the
+     * build.
+     * @ignore
+     */
     _onCompilationEnds() {
         if (this._entry && !this._running) {
             this._instance = fork(this._entryPath);
@@ -95,18 +165,28 @@ class WebpackNodeUtilsRunner {
             this._running = true;
         }
     }
-
+    /**
+     * This is a utility method used when validating the assets. If the plugin needs to fallback
+     * because no entry was specified or the one specified doesn't exist, the plugin uses this
+     * method to log all available entries for the developer to choose.
+     * @param {Array} entries The list of entries.
+     */
     _logAvailableEntries(entries) {
         const list = entries.join(', ');
         this._logInfo(`These are the available entries: ${list}`);
     }
-
+    /**
+     * A utility method the plugin uses to log messages with the plugin name as a prefix and an
+     * specific color (from the `colors` package).
+     * @param {String} msg   The message to log.
+     * @param {String} color The name of the color to use. It must be available on the `colors`
+     *                       package.
+     */
     _log(msg, color) {
         const logMsg = msg ? `[WebpackNodeUtilsRunner] ${msg}` : '';
         const logColor = color || 'white';
         console.log(colors[logColor](logMsg));
     }
-
 }
 
 module.exports = WebpackNodeUtilsRunner;

--- a/src/runner.js
+++ b/src/runner.js
@@ -1,0 +1,112 @@
+/* eslint strict: 0, no-console:0, class-methods-use-this:0 */
+
+'use strict';
+
+const path = require('path');
+const fork = require('child_process').fork;
+const colors = require('colors/safe');
+
+class WebpackNodeUtilsRunner {
+
+    constructor(entry) {
+        this._entry = entry || null;
+        this._entryPath = null;
+        this._running = false;
+        this._instance = null;
+        this._setup = false;
+        this._logColors = {
+            info: 'grey',
+            error: 'red',
+            warn: 'yellow',
+            success: 'green',
+        };
+
+        this._defineLogMethods();
+        this._bindMethods();
+    }
+
+    apply(compiler) {
+        compiler.plugin('after-emit', this._onAssetsEmitted);
+        compiler.plugin('compile', this._onCompilationStarts);
+        compiler.plugin('done', this._onCompilationEnds);
+    }
+
+    _defineLogMethods() {
+        Object.keys(this._logColors).forEach((name) => {
+            const fname = name.substr(0, 1).toUpperCase() + name.substr(1);
+            this[`_log${fname}`] = msg => this._log(msg, this._logColors[name]);
+        });
+    }
+
+    _bindMethods() {
+        [
+            'apply',
+            '_onAssetsEmitted',
+            '_onCompilationStarts',
+            '_onCompilationEnds',
+        ].forEach(m => (this[m] = this[m].bind(this)));
+    }
+
+    _onAssetsEmitted(compilation, callback) {
+        if (!this._setup) {
+            this._setup = true;
+            const entries = Object.keys(compilation.assets)
+                .filter(a => a.indexOf('hot-update') < 0);
+
+            this._log();
+            if (this._entry && entries.indexOf(this._entry) === -1) {
+                this._logError(`The required entry (${this._entry}) doesn't exist`);
+                this._entry = null;
+                this._logAvailableEntries(entries);
+            } else if (!this._entry && entries.length === 1) {
+                this._entry = entries[0];
+                this._logSuccess(`Using the only available entry: ${this._entry}`);
+            } else if (!this._entry && entries.length > 1) {
+                this._entry = entries[0];
+                this._logWarn(`Doing fallback to the first entry: ${this._entry}`);
+                this._logAvailableEntries(entries);
+            } else {
+                this._logSuccess(`Using the following entry: ${this._entry}`);
+            }
+
+            if (this._entry) {
+                this._entryPath = path.resolve(compilation.assets[this._entry].existsAt);
+                this._logSuccess(`Entry file: ${this._entryPath}`);
+            }
+        }
+
+        callback();
+    }
+
+    _onCompilationStarts() {
+        if (this._entry && this._running && this._instance) {
+            this._logInfo('Stopping bundle process');
+            this._instance.kill();
+            this._instance = null;
+            this._running = false;
+        }
+    }
+
+    _onCompilationEnds() {
+        if (this._entry && !this._running) {
+            this._instance = fork(this._entryPath);
+            this._log();
+            this._logSuccess('Starting bundle process');
+            this._running = true;
+        }
+    }
+
+    _logAvailableEntries(entries) {
+        const list = entries.join(', ');
+        this._logInfo(`These are the available entries: ${list}`);
+    }
+
+    _log(msg, color) {
+        const logMsg = msg ? `[WebpackNodeUtilsRunner] ${msg}` : '';
+        const logColor = color || 'white';
+        console.log(colors[logColor](logMsg));
+    }
+
+}
+
+module.exports = WebpackNodeUtilsRunner;

--- a/src/runner.js
+++ b/src/runner.js
@@ -8,6 +8,7 @@ const colors = require('colors/safe');
 /**
  * This is a Webpack plugin for Node apps that allows the developer to start/stop the bundle
  * execution while Webpack _watches_ the files.
+ * Based on https://github.com/ericclemmons/start-server-webpack-plugin.
  * @class
  */
 class WebpackNodeUtilsRunner {

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -1,4 +1,4 @@
-/* eslint strict: 0, global-require: 0, new-cap: 0 */
+/* eslint global-require: 0, new-cap: 0 */
 
 jest.unmock('../src/index');
 jest.unmock('fs');

--- a/tests/mocks/compiler.js
+++ b/tests/mocks/compiler.js
@@ -1,0 +1,18 @@
+'use strict';
+
+module.exports = class FakeCompiler {
+
+    constructor() {
+        this.callbacks = [];
+    }
+
+    plugin(event, callback) {
+        this.callbacks[event] = callback;
+    }
+
+    trigger(event, args) {
+        args = args || [];
+        this.callbacks[event].apply(undefined, args);
+    }
+
+};

--- a/tests/runner.test.js
+++ b/tests/runner.test.js
@@ -1,0 +1,328 @@
+/* eslint no-console: 0 */
+
+'use strict';
+
+jest.unmock('../src/runner');
+jest.mock('child_process');
+const WebpackNodeUtilsRunner = require('../src/runner');
+const FakeCompiler = require('./mocks/compiler');
+const fork = require('child_process').fork;
+const originalLog = console.log;
+require('jasmine-expect');
+
+const forkKill = jest.fn();
+fork.mockImplementation(() => ({
+    kill: forkKill,
+}));
+
+const getLogMock = () => {
+    const mock = jest.fn();
+    spyOn(console, 'log').and.callFake(mock);
+    return mock;
+};
+
+describe('webpack-node-utils-runner', () => {
+    afterEach(() => {
+        console.log = originalLog;
+        forkKill.mockClear();
+        fork.mockClear();
+    });
+
+    it('should return an instance of WebpackNodeUtilsRunner', () => {
+        const sub = new WebpackNodeUtilsRunner();
+        expect(sub instanceof WebpackNodeUtilsRunner).toBeTrue();
+    });
+
+    it('should add the callbacks to the compiler', () => {
+        const compiler = new FakeCompiler();
+        const sub = new WebpackNodeUtilsRunner();
+        expect(compiler.callbacks['after-emit']).toBeUndefined();
+        expect(compiler.callbacks.compile).toBeUndefined();
+        expect(compiler.callbacks.done).toBeUndefined();
+        sub.apply(compiler);
+        expect(compiler.callbacks['after-emit']).toBeFunction();
+        expect(compiler.callbacks.compile).toBeFunction();
+        expect(compiler.callbacks.done).toBeFunction();
+    });
+
+    it('should validate the existence of the entry on compilation time', () => {
+        const entry = 'app';
+        const compilation = {
+            assets: {
+                backend: {
+                    existsAt: './backend.js',
+                },
+                app: {
+                    existsAt: './app.js',
+                },
+            },
+        };
+
+        const compiler = new FakeCompiler();
+        const sub = new WebpackNodeUtilsRunner(entry);
+        const callback = jest.fn();
+        const log = getLogMock();
+
+        sub.apply(compiler);
+        compiler.trigger('after-emit', [compilation, callback]);
+
+        expect(log.mock.calls.length).toBe(3);
+        expect(log.mock.calls[0][0]).toBeEmptyString();
+        expect(log.mock.calls[1][0]).toContain(`Using the following entry: ${entry}`);
+        expect(log.mock.calls[2][0]).toContain('Entry file:');
+
+        expect(callback.mock.calls.length).toBe(1);
+    });
+
+    it('shouldn\'t be able to find a valid entry on compilation time', () => {
+        const entry = 'random';
+        const compilation = {
+            assets: {
+                backend: {
+                    existsAt: './backend.js',
+                },
+                app: {
+                    existsAt: './app.js',
+                },
+            },
+        };
+        const assetsList = Object.keys(compilation.assets).join(', ');
+
+        const compiler = new FakeCompiler();
+        const sub = new WebpackNodeUtilsRunner(entry);
+        const callback = jest.fn();
+        const log = getLogMock();
+
+        sub.apply(compiler);
+        compiler.trigger('after-emit', [compilation, callback]);
+
+        expect(log.mock.calls.length).toBe(3);
+        expect(log.mock.calls[0][0]).toBeEmptyString();
+        expect(log.mock.calls[1][0]).toContain(`The required entry (${entry}) doesn\'t exist`);
+        expect(log.mock.calls[2][0]).toContain(`These are the available entries: ${assetsList}`);
+        expect(callback.mock.calls.length).toBe(1);
+    });
+
+    it('should use the only available entry if the list only contains one item', () => {
+        const compilation = {
+            assets: {
+                backend: {
+                    existsAt: './backend.js',
+                },
+            },
+        };
+        const entry = Object.keys(compilation.assets)[0];
+
+        const compiler = new FakeCompiler();
+        const sub = new WebpackNodeUtilsRunner();
+        const callback = jest.fn();
+        const log = getLogMock();
+
+        sub.apply(compiler);
+        compiler.trigger('after-emit', [compilation, callback]);
+        expect(log.mock.calls[0][0]).toBeEmptyString();
+        expect(log.mock.calls[1][0]).toContain(`Using the only available entry: ${entry}`);
+        expect(log.mock.calls[2][0]).toContain('Entry file:');
+
+        expect(callback.mock.calls.length).toBe(1);
+    });
+
+    it('should use the first entry if there wasn\'t one set and list has more than one', () => {
+        const compilation = {
+            assets: {
+                backend: {
+                    existsAt: './backend.js',
+                },
+                app: {
+                    existsAt: './app.js',
+                },
+            },
+        };
+        const entry = Object.keys(compilation.assets)[0];
+        const assetsList = Object.keys(compilation.assets).join(', ');
+
+        const compiler = new FakeCompiler();
+        const sub = new WebpackNodeUtilsRunner();
+        const callback = jest.fn();
+        const log = getLogMock();
+
+        sub.apply(compiler);
+        compiler.trigger('after-emit', [compilation, callback]);
+
+        expect(log.mock.calls.length).toBe(4);
+        expect(log.mock.calls[0][0]).toBeEmptyString();
+        expect(log.mock.calls[1][0]).toContain(`Doing fallback to the first entry: ${entry}`);
+        expect(log.mock.calls[2][0]).toContain(`These are the available entries: ${assetsList}`);
+        expect(log.mock.calls[3][0]).toContain('Entry file:');
+        expect(callback.mock.calls.length).toBe(1);
+    });
+
+    it('should\'t try to find the entry more than once', () => {
+        const entry = 'app';
+        const compilation = {
+            assets: {
+                app: {
+                    existsAt: './app.js',
+                },
+            },
+        };
+
+        const compiler = new FakeCompiler();
+        const sub = new WebpackNodeUtilsRunner(entry);
+        const callback = jest.fn();
+        const log = getLogMock();
+
+        sub.apply(compiler);
+        compiler.trigger('after-emit', [compilation, callback]);
+
+        expect(log.mock.calls.length).toBe(3);
+        expect(log.mock.calls[0][0]).toBeEmptyString();
+        expect(log.mock.calls[1][0]).toContain(`Using the following entry: ${entry}`);
+        expect(log.mock.calls[2][0]).toContain('Entry file:');
+        expect(callback.mock.calls.length).toBe(1);
+
+        compiler.trigger('after-emit', [compilation, callback]);
+        expect(log.mock.calls.length).toBe(3);
+        expect(callback.mock.calls.length).toBe(2);
+    });
+
+    it('should run the build when compilation ends', () => {
+        const entry = 'app';
+        const compilation = {
+            assets: {
+                app: {
+                    existsAt: 'app.js',
+                },
+            },
+        };
+
+        const compiler = new FakeCompiler();
+        const sub = new WebpackNodeUtilsRunner(entry);
+        const callback = jest.fn();
+        const log = getLogMock();
+
+        sub.apply(compiler);
+        compiler.trigger('after-emit', [compilation, callback]);
+        compiler.trigger('done');
+
+        expect(fork.mock.calls.length).toBe(1);
+
+        expect(log.mock.calls.length).toBe(5);
+        expect(log.mock.calls[4][0]).toContain('Starting bundle process');
+        expect(callback.mock.calls.length).toBe(1);
+    });
+
+    it('should stop the build when compilation starts', () => {
+        const entry = 'app';
+        const compilation = {
+            assets: {
+                app: {
+                    existsAt: 'app.js',
+                },
+            },
+        };
+
+        const compiler = new FakeCompiler();
+        const sub = new WebpackNodeUtilsRunner(entry);
+        const callback = jest.fn();
+        const log = getLogMock();
+
+        sub.apply(compiler);
+        compiler.trigger('after-emit', [compilation, callback]);
+        compiler.trigger('done');
+        compiler.trigger('compile');
+
+        expect(fork.mock.calls.length).toBe(1);
+        expect(forkKill.mock.calls.length).toBe(1);
+
+        expect(log.mock.calls.length).toBe(6);
+        expect(log.mock.calls[4][0]).toContain('Starting bundle process');
+        expect(log.mock.calls[5][0]).toContain('Stopping bundle process');
+        expect(callback.mock.calls.length).toBe(1);
+    });
+
+    it('should restart the build when it changes', () => {
+        const numberOfChanges = 3;
+        const entry = 'app';
+        const compilation = {
+            assets: {
+                app: {
+                    existsAt: 'app.js',
+                },
+            },
+        };
+
+        const compiler = new FakeCompiler();
+        const sub = new WebpackNodeUtilsRunner(entry);
+        const callback = jest.fn();
+        const log = getLogMock();
+
+        sub.apply(compiler);
+        compiler.trigger('after-emit', [compilation, callback]);
+        compiler.trigger('done');
+        for (let i = 0; i < numberOfChanges; i++) {
+            compiler.trigger('compile');
+            compiler.trigger('done');
+        }
+
+        const baseLogCalls = 5;
+        const logsForCall = 3;
+        expect(log.mock.calls.length).toBe(baseLogCalls + (numberOfChanges * logsForCall));
+        for (let i = baseLogCalls; i < log.mock.calls.length; i += logsForCall) {
+            expect(log.mock.calls[i][0]).toContain('Stopping bundle process');
+            expect(log.mock.calls[i + 1][0]).toBeEmptyString();
+            expect(log.mock.calls[i + 2][0]).toContain('Starting bundle process');
+        }
+
+        expect(callback.mock.calls.length).toBe(1);
+    });
+
+    it('shouldn\'t stop the build if it\'s not running', () => {
+        const entry = 'app';
+        const compilation = {
+            assets: {
+                app: {
+                    existsAt: 'app.js',
+                },
+            },
+        };
+
+        const compiler = new FakeCompiler();
+        const sub = new WebpackNodeUtilsRunner(entry);
+        const callback = jest.fn();
+        const log = getLogMock();
+
+        sub.apply(compiler);
+        compiler.trigger('after-emit', [compilation, callback]);
+        compiler.trigger('compile');
+
+        expect(log.mock.calls.length).toBe(3);
+        expect(forkKill.mock.calls.length).toBe(0);
+        expect(callback.mock.calls.length).toBe(1);
+    });
+
+    it('shouldn\'t start the build if it\'s already running', () => {
+        const entry = 'app';
+        const compilation = {
+            assets: {
+                app: {
+                    existsAt: 'app.js',
+                },
+            },
+        };
+
+        const compiler = new FakeCompiler();
+        const sub = new WebpackNodeUtilsRunner(entry);
+        const callback = jest.fn();
+        const log = getLogMock();
+
+        sub.apply(compiler);
+        compiler.trigger('after-emit', [compilation, callback]);
+        compiler.trigger('done');
+        compiler.trigger('done');
+
+        expect(log.mock.calls.length).toBe(5);
+        expect(fork.mock.calls.length).toBe(1);
+        expect(callback.mock.calls.length).toBe(1);
+    });
+});


### PR DESCRIPTION
### What does this PR do?

It adds the `WebpackNodeUtilsRunner` plugin to start/stop a node build while Webpack watches the files.

The plugin can be `import`ed/`require`d from the library main package:

```js
import { WebpackNodeUtilsRunner } from 'webpack-node-utils';
// or
const WebpackNodeUtilsRunner = require('webpack-node-utils').WebpackNodeUtilsRunner;
```

And it only receives one (optional) parameter: The name of the asset you want to run when Webpack finishes building.
If no parameter is specified, it will use the first one it can find from the list of assets.

### How should it be tested manually?

1. Include the plugin on your Webpack configuration.
2. Build your project with the `--watch` flag.
3. Make a change on any of the build files, you should see the logs from the plugin saying that the process was stopped and started again.
